### PR TITLE
fix: Adjust the timing of config loading

### DIFF
--- a/addons/sourcemod/scripting/PointServerCommandFilter.sp
+++ b/addons/sourcemod/scripting/PointServerCommandFilter.sp
@@ -47,7 +47,7 @@ public Plugin myinfo =
 	name = "PointServerCommandFilter",
 	author = "BotoX",
 	description = "Filters point_servercommand->Command() using user-defined rules to restrict maps.",
-	version = "1.1",
+	version = "1.1.1",
 	url = ""
 };
 
@@ -81,7 +81,10 @@ public void OnPluginStart()
 	{
 		OnEntityCreated(entity, "point_servercommand");
 	}
+}
 
+public void OnMapStart()
+{
 	LoadConfig();
 }
 


### PR DESCRIPTION
So it always apply your recent changes on each map, instead of having to reload the plugin. 